### PR TITLE
Fix for AxisItem using old scale to create label

### DIFF
--- a/pyqtgraph/graphicsItems/AxisItem.py
+++ b/pyqtgraph/graphicsItems/AxisItem.py
@@ -448,11 +448,11 @@ class AxisItem(GraphicsWidget):
             if self.labelUnits == '' and prefix in ['k', 'm']:  ## If we are not showing units, wait until 1e6 before scaling.
                 scale = 1.0
                 prefix = ''
+            self.autoSIPrefixScale = scale
             self.setLabel(unitPrefix=prefix)
         else:
-            scale = 1.0
+            self.autoSIPrefixScale = 1.0
 
-        self.autoSIPrefixScale = scale
         self.picture = None
         self.update()
 


### PR DESCRIPTION
The self.setLabel() call in updateAutoSIPrefix() was being made before the autoSIPrefixScale was written, which caused the label string to be generated with an incorrect unit in some cases.